### PR TITLE
Issue 6 basic calendar grid

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,7 +12,21 @@
       <h1>Commemorative Days Calendar</h1>
     </header>
     <main>
-      <!-- Add your code here -->
+      <section class="calendar">
+        <h2 id="month-year" class="month-year">Month Year</h2>
+
+        <div class="weekdays">
+          <div>Sun</div>
+          <div>Mon</div>
+          <div>Tue</div>
+          <div>Wed</div>
+          <div>Thu</div>
+          <div>Fri</div>
+          <div>Sat</div>
+        </div>
+
+        <div id="calendar-grid" class="calendar-grid"></div>
+      </section>
     </main>
     <footer>&copy; 2026 Project by Hadi & Chioma</footer>
   </body>

--- a/src/displayCalendar.js
+++ b/src/displayCalendar.js
@@ -1,0 +1,45 @@
+const monthYearElement = document.getElementById("month-year");
+const calendarGridElement = document.getElementById("calendar-grid");
+
+// This function returns how many days a month has.
+function getDaysInMonth(year, month) {
+  return new Date(year, month + 1, 0).getDate();
+}
+
+// This function draws one month in the calendar grid.
+export function renderMonth(year, month) {
+  calendarGridElement.innerHTML = "";
+
+  const firstDayOfMonth = new Date(year, month, 1);
+  const firstWeekday = firstDayOfMonth.getDay(); // Sunday = 0
+  const daysInMonth = getDaysInMonth(year, month);
+
+  const monthName = firstDayOfMonth.toLocaleString("en-US", {
+    month: "long",
+  });
+  monthYearElement.textContent = `${monthName} ${year}`;
+
+  // Add empty boxes before day 1 so Sunday stays first.
+  for (let i = 0; i < firstWeekday; i += 1) {
+    const emptyCell = document.createElement("div");
+    emptyCell.className = "day-cell day-cell--empty";
+    emptyCell.setAttribute("aria-hidden", "true");
+    calendarGridElement.appendChild(emptyCell);
+  }
+
+  // Add day boxes for this month.
+  for (let day = 1; day <= daysInMonth; day += 1) {
+    const dayCell = document.createElement("div");
+    dayCell.className = "day-cell";
+    dayCell.textContent = String(day);
+    calendarGridElement.appendChild(dayCell);
+  }
+}
+
+// This function shows the current month when page loads.
+export function renderCurrentMonth() {
+  const today = new Date();
+  const currentYear = today.getFullYear();
+  const currentMonth = today.getMonth();
+  renderMonth(currentYear, currentMonth);
+}

--- a/src/script.js
+++ b/src/script.js
@@ -1,0 +1,45 @@
+const monthYearElement = document.getElementById("month-year");
+const calendarGridElement = document.getElementById("calendar-grid");
+
+// This function returns how many days a month has.
+function getDaysInMonth(year, month) {
+  return new Date(year, month + 1, 0).getDate();
+}
+
+function renderMonth(year, month) {
+  calendarGridElement.innerHTML = "";
+
+  const firstDayOfMonth = new Date(year, month, 1);
+  const firstWeekday = firstDayOfMonth.getDay(); // Sunday = 0, Monday = 1...
+  const daysInMonth = getDaysInMonth(year, month);
+
+  const monthName = firstDayOfMonth.toLocaleString("en-US", {
+    month: "long",
+  });
+  monthYearElement.textContent = `${monthName} ${year}`;
+
+  // Add empty boxes before day 1 so Sunday is the first column.
+  for (let i = 0; i < firstWeekday; i += 1) {
+    const emptyCell = document.createElement("div");
+    emptyCell.className = "day-cell day-cell--empty";
+    emptyCell.setAttribute("aria-hidden", "true");
+    calendarGridElement.appendChild(emptyCell);
+  }
+
+  // Create one box for each day number.
+  for (let day = 1; day <= daysInMonth; day += 1) {
+    const dayCell = document.createElement("div");
+    dayCell.className = "day-cell";
+    dayCell.textContent = String(day);
+    calendarGridElement.appendChild(dayCell);
+  }
+}
+
+function renderCurrentMonth() {
+  const today = new Date();
+  const currentYear = today.getFullYear();
+  const currentMonth = today.getMonth();
+  renderMonth(currentYear, currentMonth);
+}
+
+renderCurrentMonth();

--- a/src/script.js
+++ b/src/script.js
@@ -1,45 +1,4 @@
-const monthYearElement = document.getElementById("month-year");
-const calendarGridElement = document.getElementById("calendar-grid");
+import { renderCurrentMonth } from "./displayCalendar.js";
 
-// This function returns how many days a month has.
-function getDaysInMonth(year, month) {
-  return new Date(year, month + 1, 0).getDate();
-}
-
-function renderMonth(year, month) {
-  calendarGridElement.innerHTML = "";
-
-  const firstDayOfMonth = new Date(year, month, 1);
-  const firstWeekday = firstDayOfMonth.getDay(); // Sunday = 0, Monday = 1...
-  const daysInMonth = getDaysInMonth(year, month);
-
-  const monthName = firstDayOfMonth.toLocaleString("en-US", {
-    month: "long",
-  });
-  monthYearElement.textContent = `${monthName} ${year}`;
-
-  // Add empty boxes before day 1 so Sunday is the first column.
-  for (let i = 0; i < firstWeekday; i += 1) {
-    const emptyCell = document.createElement("div");
-    emptyCell.className = "day-cell day-cell--empty";
-    emptyCell.setAttribute("aria-hidden", "true");
-    calendarGridElement.appendChild(emptyCell);
-  }
-
-  // Create one box for each day number.
-  for (let day = 1; day <= daysInMonth; day += 1) {
-    const dayCell = document.createElement("div");
-    dayCell.className = "day-cell";
-    dayCell.textContent = String(day);
-    calendarGridElement.appendChild(dayCell);
-  }
-}
-
-function renderCurrentMonth() {
-  const today = new Date();
-  const currentYear = today.getFullYear();
-  const currentMonth = today.getMonth();
-  renderMonth(currentYear, currentMonth);
-}
-
+// Start the first calendar view.
 renderCurrentMonth();

--- a/style.css
+++ b/style.css
@@ -1,0 +1,70 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: Arial, sans-serif;
+  background-color: #f4f4f4;
+  color: #222;
+}
+
+header,
+footer {
+  text-align: center;
+  padding: 1rem;
+}
+
+main {
+  display: flex;
+  justify-content: center;
+  padding: 1rem;
+}
+
+.calendar {
+  width: 100%;
+  max-width: 900px;
+  background-color: #fff;
+  padding: 1rem;
+  border-radius: 8px;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.08);
+}
+
+.month-year {
+  margin-top: 0;
+  text-align: center;
+}
+
+.weekdays {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 0.4rem;
+  margin-bottom: 0.4rem;
+}
+
+.weekdays div {
+  text-align: center;
+  padding: 0.5rem 0.2rem;
+  font-weight: bold;
+  background-color: #e9eef7;
+  border-radius: 6px;
+}
+
+.calendar-grid {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  gap: 0.4rem;
+}
+
+.day-cell {
+  min-height: 70px;
+  padding: 0.5rem;
+  border: 1px solid #d8d8d8;
+  border-radius: 6px;
+  background-color: #fafafa;
+}
+
+.day-cell--empty {
+  background-color: #f0f0f0;
+  border-style: dashed;
+}


### PR DESCRIPTION
## Summary
This PR implements Issue #6 by creating a simple and beginner-friendly calendar shell.

## What I changed
- Added basic calendar HTML structure in `index.html`
- Added weekdays row with Sunday as the first column
- Added CSS for a 7-column calendar grid and day boxes in `style.css`
- Added simple JavaScript in `src/script.js` to:
  - show current month and year
  - render all days of the current month
  - add empty padding cells before day 1 (when needed)

## Why
This builds the base calendar UI needed for the next features (like Prev/Next navigation).

## How to test
1. Open the project in browser.
2. Check month/year title shows the current month.
3. Check weekday order starts with `Sun`.
4. Check all days of current month are displayed.
5. Check leading empty cells appear if the month does not start on Sunday.

## Acceptance Criteria
- [x] 7-column grid (Sunday first)
- [x] all current month days shown as rectangles
- [x] leading padding is handled correctly
- [x] current month is shown on page load
